### PR TITLE
Creste nut run folder in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
 
+RUN mkdir -p /var/run/nut/
+
 RUN apk add --no-cache nut
 
 EXPOSE 3493


### PR DESCRIPTION
# Describe

`/var/run/nut/` is required for socket and PIDs but doesn't exist